### PR TITLE
Fix bucket name configuration

### DIFF
--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/extendeds3/ExtendedS3StorageTest.java
@@ -57,7 +57,7 @@ import org.junit.Before;
  */
 @Slf4j
 public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
-    private static final String BUCKET_NAME = "pravegatest";
+    private static final String BUCKET_NAME_PREFIX = "pravegatest-";
     private ExtendedS3StorageFactory storageFactory;
     private ExtendedS3StorageConfig adapterConfig;
     private S3JerseyClient client = null;
@@ -93,15 +93,15 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
 
         s3Proxy.start();
 
+        String bucketName = BUCKET_NAME_PREFIX + UUID.randomUUID().toString();
         this.adapterConfig = ExtendedS3StorageConfig.builder()
-                                                    .with(ExtendedS3StorageConfig.BUCKET, BUCKET_NAME)
+                                                    .with(ExtendedS3StorageConfig.BUCKET, bucketName)
                                                     .with(ExtendedS3StorageConfig.ACCESS_KEY_ID, "x")
                                                     .with(ExtendedS3StorageConfig.SECRET_KEY, "x")
                                                     .with(ExtendedS3StorageConfig.ROOT, "test")
                                                     .with(ExtendedS3StorageConfig.URI, endpoint)
                                                     .build();
         createStorage();
-        String bucketName = BUCKET_NAME + UUID.randomUUID().toString();
         client.createBucket(bucketName);
         List<ObjectKey> keys = client.listObjects(bucketName).getObjects().stream().map((object) -> {
             return new ObjectKey(object.getKey());


### PR DESCRIPTION
**Change log description**
* Fix the bucket name being passed to the storage configuration in `ExtendedS3StorageTest`.

**Purpose of the change**
Fix an issue with the bucket name in the extended S3 tests.

**What the code does**
Fixes a configuration parameter, add the correct name to the configuration.

**How to verify it**
Run tests.